### PR TITLE
WS-2589: Remove genre option from entities example

### DIFF
--- a/examples/entities.rb
+++ b/examples/entities.rb
@@ -12,8 +12,7 @@ rosette_api = if url
 
 entities_text_data = 'The Securities and Exchange Commission today announced the leadership of the agency\'s trial unit. Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency\'s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency\'s Washington D.C. headquarters as well as coordinating with litigators in the SEC\'s 11 regional offices around the country.'
 begin
-  params = DocumentParameters.new(content: entities_text_data,
-                                  genre: 'social-media')
+  params = DocumentParameters.new(content: entities_text_data)
   response = rosette_api.get_entities(params)
   puts JSON.pretty_generate(response)
 rescue RosetteAPIError => e

--- a/lib/rosette_api.rb
+++ b/lib/rosette_api.rb
@@ -9,6 +9,9 @@ require_relative 'address_similarity_parameters'
 require_relative 'rosette_api_error'
 require_relative 'bad_request_error'
 require_relative 'bad_request_format_error'
+require 'logger'
+
+
 
 # This class allows you to access all Rosette API endpoints.
 class RosetteAPI
@@ -65,6 +68,7 @@ class RosetteAPI
   attr_accessor :url_parameters
 
   def initialize(user_key, alternate_url = 'https://api.rosette.com/rest/v1')
+    @log = Logger.new(STDOUT)
     @user_key = user_key
     @alternate_url = alternate_url
     @url_parameters = nil
@@ -530,5 +534,8 @@ class RosetteAPI
                    message = 'Expects a DocumentParameters type as an argument',
                    type = DocumentParameters)
     raise BadRequestError.new message unless params.is_a? type
+    if defined?(params.genre) && !params.genre.nil?
+      @log.warn("The genre parameter is deprecated and will be removed in a future release.")
+    end
   end
 end


### PR DESCRIPTION
This PR is needed to remove the `genre` field from the entities example, and warn in case of its use.